### PR TITLE
Implement resume for previously paused media players

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Features in released versions
 * 0.1.0 - Pause videos on Youtube only
 * 0.2.0 - Pause videos on other common sites with video content (e.g. Vimeo, Twitter, and others)
 * 0.3.0 - Pause sound on common sites with audio content (HTML5 compatible ones - e.g. RNZ)
+* 0.4.0 - Resume playback on tabs that were playing at the time
 
 Release targets for upcoming releases are tentative only:
 
-* 0.4.0 - Resume playback on tabs that were playing at the time
 * 0.5.0 - Pause Brightcove based players, news sites (e.g. CNN, NBC, stuff.co.nz, herald.co.nz)
 * 0.6.0 - Pause audio streaming sites (e.g. Soundcloud, Spotify)
 * 0.7.0 - Add option for pausing all videos (including all that don't have sound), by using a more brute-force

--- a/src/background.js
+++ b/src/background.js
@@ -8,14 +8,24 @@ function stopAllPlayback()
 	// All tabs have "audible = true" set
 	//
 	// In theory, all of these tabs should have one or more media elements that are generating
-	// sound events, so these are the ones we should be targetting for stopping playback.
-	//
-	// TODO: Implement support for storing which ones we muted, so we can restore playback
+	// sound events, so these are the ones we should be targeting for stopping playback.
 	chrome.tabs.query({audible: true}, function(tabs) {
 		for (let tab of tabs) {
-			chrome.tabs.sendMessage(tab.id, {"message": "stop_all_media"});
+			chrome.tabs.sendMessage(tab.id, {"message": "pause_all_media"});
 		}
 	});
+}
+
+// Sends a message to restore the previous audio / video play state
+function restorePlaybackState(){
+	console.log("[GobStopper] Restoring All Playback...")
+
+	chrome.tabs.query({audible: true}, function(tabs) {
+		for (let tab of tabs) {
+			chrome.tabs.sendMessage(tab.id, {"message": "play_paused_media"});
+		}
+	});
+	
 }
 
 // Called when the user clicks on the browser action.
@@ -27,6 +37,12 @@ chrome.browserAction.onClicked.addListener(function(tab) {
 // Called when the user presses the Global Stop-All hotkey.
 browser.commands.onCommand.addListener(function(command) {
 	if (command == "stop-all") {
-		stopAllPlayback();
+		dataInStorage = browser.storage.local.length != 0
+		console.log(browser.storage.local.length);
+		if (dataInStorage){
+			restorePlaybackState();
+		} else {
+			stopAllPlayback();
+		}
 	}
 });

--- a/src/background.js
+++ b/src/background.js
@@ -22,14 +22,13 @@ function stopAllPlayback()
 
 // Sends a message to restore the previous audio / video play state
 function restorePlaybackState(){
-	console.log("[GobStopper] Restoring All Playback...")
+	console.log("[GobStopper] Restoring previous streams...")
 
 	chrome.tabs.query({audible: true}, function(tabs) {
 		for (let tab of tabs) {
 			chrome.tabs.sendMessage(tab.id, {"message": "play_paused_media"});
 		}
 	});
-	
 }
 
 // Called when the user clicks on the browser action.
@@ -42,12 +41,11 @@ chrome.browserAction.onClicked.addListener(function(tab) {
 browser.commands.onCommand.addListener(function(command) {
 	if (command == "stop-all") {
 		browser.storage.local.get(null, function(item){
-			console.log(item)
 			if (!isEmptyObject(item)) {
 				restorePlaybackState();
 			} else {
 				stopAllPlayback();
-			}		
+			}
 		});
 	}
 });

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,9 @@
 // background.js
 
+function isEmptyObject(obj){
+	return Object.keys(obj).length === 0 && obj.constructor === Object
+}
+
 // Send a message to all the tabs to stop playback
 function stopAllPlayback()
 {
@@ -37,12 +41,13 @@ chrome.browserAction.onClicked.addListener(function(tab) {
 // Called when the user presses the Global Stop-All hotkey.
 browser.commands.onCommand.addListener(function(command) {
 	if (command == "stop-all") {
-		dataInStorage = browser.storage.local.length != 0
-		console.log(browser.storage.local.length);
-		if (dataInStorage){
-			restorePlaybackState();
-		} else {
-			stopAllPlayback();
-		}
+		browser.storage.local.get(null, function(item){
+			console.log(item)
+			if (!isEmptyObject(item)) {
+				restorePlaybackState();
+			} else {
+				stopAllPlayback();
+			}		
+		});
 	}
 });

--- a/src/content.js
+++ b/src/content.js
@@ -1,13 +1,13 @@
 // content.js
 
-// Gets all elements by the given name and return them as an array
+// Gets all elements by the given names and return them as an array
 function GetElementCollectionByTagNames(names){
 	elements = [];
 	names.forEach(function(name){
 		for (let video of document.getElementsByTagName(name)) {
 			elements.push(video);
-		}	
-	})
+		}
+	});
 	return elements;
 }
 
@@ -24,19 +24,20 @@ chrome.runtime.onMessage.addListener(
 					media.pause();
 					pausedSources.push(media.currentSrc)
 				}
-			})
-			browser.storage.local.set({"MediaSources": pausedSources});
+			});
+			browser.storage.local.set({"PausedSources": pausedSources});
 		}
 
 		// Restart playback
 		if (request.message === "play_paused_media") {
-			browser.storage.local.get("MediaSources", function(pausedEntries){
+			browser.storage.local.get("PausedSources", function(data){
 				mediaElements.forEach(function(media){
-					if ((media.paused) && (pausedEntries.MediaSources.indexOf(media.currentSrc) > -1)) {
+					if ((media.paused) && (data.PausedSources.indexOf(media.currentSrc) > -1)) {
 						media.play();
 					}
-				})
+				});
 			});
+			// no need to keep the paused sources, everything is in play back mode again
 			browser.storage.local.clear();
 		}
 	}

--- a/src/content.js
+++ b/src/content.js
@@ -1,19 +1,46 @@
 // content.js
+
+// Gets all elements by the given name and return them as an array
+function GetElementCollectionByTagNames(names){
+	elements = [];
+	names.forEach(function(name){
+		for (let video of document.getElementsByTagName(name)) {
+			elements.push(video);
+		}	
+	})
+	return elements;
+}
+
 chrome.runtime.onMessage.addListener(
 	function(request, sender, sendResponse) {
-		if (request.message === "stop_all_media") {
-			for (let video of document.getElementsByTagName("video")) {
-				if (!video.paused) {
-					video.pause();
+		
+		// First, get all possibly affected elements
+		mediaElements = GetElementCollectionByTagNames(["video","audio"])
+		
+		// Pause playback
+		if (request.message === "pause_all_media") {
+			pausedSrcs = {};
+			mediaElements.forEach(function(media){
+				if (!media.paused) {
+					pausedSrcs[media.currentSrc] = media.currentSrc
+					media.pause();
 				}
-			}
-			for (let audio of document.getElementsByTagName("audio")) {
-				if (!audio.paused) {
-					audio.pause();
+			})
+			browser.storage.local.set(pausedSrcs);
+		}
+
+		// Restart playback
+		if (request.message === "play_paused_media") {
+			console.log("here");
+			mediaElements.forEach(function(media){
+				if (media.paused) {
+					browser.storage.local.get(media.currentSrc, function(src){
+						console.log("entry in storage found");
+						media.play();
+					})
 				}
-			}
+			})
+			browser.storage.local.clear();
 		}
 	}
 );
-
-

--- a/src/content.js
+++ b/src/content.js
@@ -13,33 +13,30 @@ function GetElementCollectionByTagNames(names){
 
 chrome.runtime.onMessage.addListener(
 	function(request, sender, sendResponse) {
-		
 		// First, get all possibly affected elements
 		mediaElements = GetElementCollectionByTagNames(["video","audio"])
 		
 		// Pause playback
 		if (request.message === "pause_all_media") {
-			pausedSrcs = {};
+			pausedSources = [];
 			mediaElements.forEach(function(media){
 				if (!media.paused) {
-					pausedSrcs[media.currentSrc] = media.currentSrc
 					media.pause();
+					pausedSources.push(media.currentSrc)
 				}
 			})
-			browser.storage.local.set(pausedSrcs);
+			browser.storage.local.set({"MediaSources": pausedSources});
 		}
 
 		// Restart playback
 		if (request.message === "play_paused_media") {
-			console.log("here");
-			mediaElements.forEach(function(media){
-				if (media.paused) {
-					browser.storage.local.get(media.currentSrc, function(src){
-						console.log("entry in storage found");
+			browser.storage.local.get("MediaSources", function(pausedEntries){
+				mediaElements.forEach(function(media){
+					if ((media.paused) && (pausedEntries.MediaSources.indexOf(media.currentSrc) > -1)) {
 						media.play();
-					})
-				}
-			})
+					}
+				})
+			});
 			browser.storage.local.clear();
 		}
 	}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,8 @@
 	"author": "Aligorith",
 	
 	"permissions": [
-		"tabs"
+		"tabs",
+		"storage"
 	],
 	"content_scripts": [
 		{

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,9 +1,9 @@
 {
 	"manifest_version": 2,
 	"name": "Gob Stopper",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "One-click button to pause all media players",
-	"author": "Aligorith",
+	"author": "Aligorith. Plasmasolutions",
 	
 	"permissions": [
 		"tabs",
@@ -32,6 +32,6 @@
 	},
 	"browser_action": {
 		"default_icon": "icon.svg",
-		"default_title": "Click to stop all media players (Shortcut: F4)"
+		"default_title": "Click to pause all media players (Shortcut: F4)"
 	}
 }


### PR DESCRIPTION
Hi Joshua,

as promised, here is a little help from a fellow Blender dev. I used the local storage to save the previously paused media players and renamed some actions to better reflect what they are doing. I'm not quite happy about the stop-all command (only the name) but as the user can't see it either way, it does not bother me too much.

Hope you like the little addition,
CU at Bcon19?!